### PR TITLE
Handling grouped selectors with :matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ module.exports = function() {
     return arr;
   }
 
+  function isNotMatchesSelector(selector) {
+    return selector.indexOf(':matches(') === -1;
+  }
+
   return function(style) {
     style.rules.forEach(function replaceMatches(rule) {
       if (rule.rules) {
@@ -37,6 +41,7 @@ module.exports = function() {
       var actualSelectors = rule.selectors.join(',').replace(/:matches\(.*?\)/g, function(substr) {
         return substr.replace(/,/g, COMMA_PLACEHOLDER);
       }).split(',');
+
       rule.selectors = actualSelectors;
       rule.selectors.forEach(function findMatchesSelector(selector, i) {
         var options, match, values, matches, lastIndex;
@@ -63,10 +68,11 @@ module.exports = function() {
             lastIndex = MATCH_REGEX.lastIndex;
           }
 
-          rule.selectors.splice(i, 1);
           addCartesianSelectors(selector, matches, values, rule.selectors);
         }
       });
+
+      rule.selectors = rule.selectors.filter(isNotMatchesSelector);
     });
   };
 };

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function() {
 
       // Unfortunately rework unconditionally splits selectors by comma, so our
       // :matches(...) selector gets munged.
-      var actualSelectors = rule.selectors.join(',').replace(/:matches\(.*\)/g, function(substr) {
+      var actualSelectors = rule.selectors.join(',').replace(/:matches\(.*?\)/g, function(substr) {
         return substr.replace(/,/g, COMMA_PLACEHOLDER);
       }).split(',');
       rule.selectors = actualSelectors;

--- a/test/css/matches.css
+++ b/test/css/matches.css
@@ -1,4 +1,5 @@
-.foo:matches(:hover, :active, :focus) {
+.foo:matches(:hover, :active, :focus),
+.baz:matches(:hover, :active, :focus) {
   background: red;
 }
 

--- a/test/css/matches.css
+++ b/test/css/matches.css
@@ -3,6 +3,12 @@
   background: red;
 }
 
+.foo .bar .baz,
 .bar :matches(div, p) :matches(.baz, .foo) {
   background: blue;
+}
+
+.bar :matches(div, p) :matches(.baz, .foo),
+.foo .bar .baz {
+  color: tomato;
 }

--- a/test/css/matches.out.css
+++ b/test/css/matches.out.css
@@ -1,6 +1,9 @@
 .foo:hover,
 .foo:active,
-.foo:focus {
+.foo:focus,
+.baz:hover,
+.baz:active,
+.baz:focus {
   background: red;
 }
 

--- a/test/css/matches.out.css
+++ b/test/css/matches.out.css
@@ -7,9 +7,18 @@
   background: red;
 }
 
+.foo .bar .baz,
 .bar div .baz,
 .bar div .foo,
 .bar p .baz,
 .bar p .foo {
   background: blue;
+}
+
+.foo .bar .baz,
+.bar div .baz,
+.bar div .foo,
+.bar p .baz,
+.bar p .foo {
+  color: tomato;
 }

--- a/test/css/no-matches.css
+++ b/test/css/no-matches.css
@@ -2,6 +2,7 @@
   background: red;
 }
 
-.bar {
+.bar,
+.baz {
   background: blue;
 }

--- a/test/css/no-matches.out.css
+++ b/test/css/no-matches.out.css
@@ -2,6 +2,7 @@
   background: red;
 }
 
-.bar {
+.bar,
+.baz {
   background: blue;
 }


### PR DESCRIPTION
Firstly, thanks for this plugin. It's awesome.

I've encountered an issue using `rework-matches` with grouped CSS selectors. When using a grouped selector like `.foo:matches(:hover), .bar:matches(:hover)` the output gets muddied up.

The issue arises from the fact that rework splits all selectors on commas, and you're doing some awesome magic to work around that shortcoming. In attempt to find a work around, I've introduced a failing test case that can be summarized as:

``` css
.foo:matches(:hover, :active, :focus),
.baz:matches(:hover, :active, :focus) {
  background: red;
}
```

Results in:

``` css
.foo:hover&.baz:hover,
.foo:hover&.baz:active,
.foo:hover&.baz:focus,
.foo:active&.baz:hover,
.foo:active&.baz:active,
.foo:active&.baz:focus,
.foo:focus&.baz:hover,
.foo:focus&.baz:active,
.foo:focus&.baz:focus
```

I figured I'd use this testcase as a starting point to implement a fix. It looks like the way we can discern whether the selector is part of a group or not is when we end up with a comma placeholder token, `&` in the string that's not within the `:matches` parens.

I should have a PR ready to go sometime tomorrow with a fix.

Thanks!
