### PR TITLE
Update rework version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "matches"
   ],
   "devDependencies": {
-    "rework": "~0.20.3",
+    "rework": "~1.0.1",
     "diff": "~1.0.8"
   }
 }


### PR DESCRIPTION
I uncovered a problem where whitespace for the pseudo-classes was being preserved so `.foo:matches(:hover, :active, :focus)` was processed into:

``` css
.foo:hover,
.foo :active,
.foo :focus {
  background: red;
}
```

I was perplexed.

After a bit of digging, I realized that I was using a newer version of rework (`gulp-rework` carets `1.0.0`). So, I dove quickly into the `css` module and noticed that the latest version supports `:commas(:in, :parens)` now [[branch with passing tests](https://github.com/johnotander/css/tree/matches/test/cases/matches)]. As a result, the proper [ast](https://github.com/johnotander/css/blob/matches/test/cases/matches/ast.json) is being produced. This was something that we were previously discussing in #1.

I'm creating this PR to have a quick discussion about how you'd prefer to approach a fix. This diff causes the tests to fail with the aforementioned reason. I initially see two primary routes:
1. Handle leading whitespace that might precede a pseudo-class to ensure that it's removed when added (compatible with rework `1.0.X` and `0.20.X`).
2. Nuke most of the logic with :fire:, leverage rework `1.0.X`.

The first option is probably the best, as it supports legacy rework versions. Though, the second is looking mighty nice, too. It would reduce complexity in the plugin considerably, and commas inside selectors support was added on 6/14. [[1](https://github.com/reworkcss/css/blob/master/History.md#200--2014-06-18)], [[2](https://github.com/reworkcss/rework/blob/master/History.md#100--2014-06-19)]

Any thoughts on the preferred approach would be appreciated.
